### PR TITLE
Added null as default argument for image setter

### DIFF
--- a/Classes/Domain/Model/Example.php
+++ b/Classes/Domain/Model/Example.php
@@ -94,7 +94,7 @@ class Example extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity {
 	 * @param \TYPO3\CMS\Extbase\Domain\Model\FileReference $image
 	 * @return void
 	 */
-	public function setImage($image) {
+	public function setImage($image = null) {
 		$this->image = $image;
 	}
 


### PR DESCRIPTION
In case there is a validation error on another property of the model, the file reference is not created and TYPO3 throws an execption due to the expectation of a FileReference-Object.