### PR TITLE
Update ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '0.0.1',
 	'constraints' => array(
 		'depends' => array(
-			'core' => '6.2.4-6.3.99',
+			'typo3' => '6.2.4-6.3.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
Fixed dependency, so the extension can be installed ov every TYPO3 6.2.x version and not only 6.2.4