### PR TITLE
[BUGIX] Show uploaded image on validation error for TYPO3 v8.7.x

### DIFF
--- a/Classes/ViewHelpers/Form/UploadViewHelper.php
+++ b/Classes/ViewHelpers/Form/UploadViewHelper.php
@@ -45,6 +45,11 @@ class UploadViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\UploadViewHelpe
     protected $propertyMapper;
 
     /**
+     * @var bool
+     */
+    protected $respectSubmittedDataValue = true;
+
+    /**
      * Render the upload field including possible resource pointer
      *
      * @return string


### PR DESCRIPTION
If validation fails, an uploaded image will not be shown in TYPO3 v8.7.x. Here is the fix.